### PR TITLE
Fix multiplayer game_state updates by removing invalid `mode` field

### DIFF
--- a/src/lib/gameLogic.js
+++ b/src/lib/gameLogic.js
@@ -690,10 +690,10 @@ export class GameLogic {
       current_turn: this.currentTurn,
       timer_remaining: this.timerRemaining,
       pending_check: this.pendingCheck,
-      move_history: this.moveHistory,
-      mode: this.mode
+      move_history: this.moveHistory
       // NOTE: 'scores' and 'game_state' columns DO NOT EXIST in database - removed
       // NOTE: 'pieces' exists but we don't update it after initialization
+      // NOTE: 'mode' column does NOT exist in game_state; mode stays in in-memory logic/broadcast state
       // NOTE: 'awaiting_decision' exists and is set separately in makeMove/respondToCheck
     };
   }


### PR DESCRIPTION
### Motivation
- Prevent realtime multiplayer updates from failing by ensuring `GameLogic.exportForDatabase()` only includes columns that exist in the `game_state` table (the previous payload included a `mode` field which the DB schema does not have). 

### Description
- Remove the `mode` property from the object returned by `GameLogic.exportForDatabase()` and add an inline note clarifying that `mode` is kept in in-memory/broadcast state instead of being written to `game_state` (`src/lib/gameLogic.js`).

### Testing
- Ran lint and production build: `npm run lint` and `npm run build` both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699246ab80e483228603a5e05e2f1de3)