### PR TITLE
Fix edge hint filtering to exclude corner pieces

### DIFF
--- a/src/lib/gameLogic.js
+++ b/src/lib/gameLogic.js
@@ -596,7 +596,12 @@ export class GameLogic {
         break;
       }
       case 'edge': {
-        const edgePieces = availablePieces.filter(p => p.isEdge && !p.edges.top && !p.edges.left && !p.edges.right && !p.edges.bottom);
+        const edgePieces = availablePieces.filter((p) => {
+          const edges = p.edges || {};
+          const edgeCount = [edges.top, edges.right, edges.bottom, edges.left].filter(Boolean).length;
+          // Edge hints should exclude corner pieces (which have 2 edges).
+          return p.isEdge && edgeCount === 1;
+        });
         hintInfo = {
           type: 'edge',
           edgePieceIds: edgePieces.map(p => p.id)


### PR DESCRIPTION
### Motivation
- Edge-type hints were returning incorrect sets because the previous filter logic could include corner pieces or fail when `edges` metadata was missing, affecting hint accuracy during gameplay (file: `src/lib/gameLogic.js`).

### Description
- Updated `GameLogic.useHint(..., 'edge')` to defensively read `p.edges` and compute the number of true edge sides, then only include pieces with exactly one border edge (`edgeCount === 1`) so corner pieces are excluded.

### Testing
- Ran a quick Node script that constructs a small `GameLogic` instance and calls `useHint('playerA', 'edge')`, which returned only the non-corner edge piece as expected. 
- Ran `npm run lint` and `npm run build`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69924525272c83229c153c8d00739d61)