### PR TITLE
Persist and sync gameplay_mode for multiplayer games

### DIFF
--- a/src/api/games.js
+++ b/src/api/games.js
@@ -137,8 +137,8 @@ export const gameStateApi = {
    * @param {number} gridSize - Total number of grid positions
    * @returns {Promise<Object>} Initial game state
    */
-  async initializeGameState(gameId, pieces, gridSize) {
-    return realtimeService.initializeGameState(gameId, pieces, gridSize);
+  async initializeGameState(gameId, pieces, gridSize, gameplayMode = 'CLASSIC') {
+    return realtimeService.initializeGameState(gameId, pieces, gridSize, gameplayMode);
   },
 
   /**

--- a/src/lib/gameLogic.js
+++ b/src/lib/gameLogic.js
@@ -691,7 +691,7 @@ export class GameLogic {
       timer_remaining: this.timerRemaining,
       pending_check: this.pendingCheck,
       move_history: this.moveHistory,
-      mode: this.mode
+      gameplay_mode: this.mode
       // NOTE: 'scores' and 'game_state' columns DO NOT EXIST in database - removed
       // NOTE: 'pieces' exists but we don't update it after initialization
       // NOTE: 'awaiting_decision' exists and is set separately in makeMove/respondToCheck
@@ -793,10 +793,11 @@ export class GameLogic {
     this.moveHistory = data.move_history || data.moveHistory || [];
     
     // Import mode data
-    if (data.mode) {
-      this.mode = data.mode;
-      this.modeConfig = importedGetModeConfig(data.mode);
-      this.modeScoring = importedGetModeScoring(data.mode);
+    const importedMode = data.gameplay_mode || data.mode;
+    if (importedMode) {
+      this.mode = importedMode;
+      this.modeConfig = importedGetModeConfig(importedMode);
+      this.modeScoring = importedGetModeScoring(importedMode);
     }
     if (data.turnsRemaining) {
       this.turnsRemaining = data.turnsRemaining;

--- a/src/lib/multiplayer.js
+++ b/src/lib/multiplayer.js
@@ -146,7 +146,8 @@ export class MultiplayerGameHost {
       await realtimeService.initializeGameState(
         game.id,
         pieces,
-        gridDimensions.totalPieces
+        gridDimensions.totalPieces,
+        settings.mode || 'CLASSIC'
       );
 
       console.log('Step 6: Setting up realtime channel (broadcast)...');
@@ -536,7 +537,7 @@ export class MultiplayerGameGuest {
       const { pieces } = await processor.sliceImage();
 
       console.log('Step 5: Initializing game logic with full pieces...');
-      this.gameLogic = new GameLogic(game.grid_size, pieces, game.mode || 'CLASSIC');
+      this.gameLogic = new GameLogic(game.grid_size, pieces, gameState?.gameplay_mode || 'CLASSIC');
       this.gameLogic.importGameState(gameState, pieces);
 
       console.log('Step 6: Setting up realtime channel (broadcast)...');

--- a/src/services/realtime.service.js
+++ b/src/services/realtime.service.js
@@ -6,7 +6,7 @@ import { supabase } from '../config/supabase';
 
 export const realtimeService = {
   // Initialize game state
-  async initializeGameState(gameId, pieces, gridSize) {
+  async initializeGameState(gameId, pieces, gridSize, gameplayMode = 'CLASSIC') {
     // Store only piece metadata, not the full imageData
     // imageData is NOT stored - it's reconstructed client-side
     const piecesMetadata = pieces.map(p => ({
@@ -34,7 +34,8 @@ export const realtimeService = {
         piece_pool: pieces.slice(20).map(p => p.id),
         pieces: piecesMetadata,  // Smaller payload without imageData
         current_turn: 'playerA',
-        timer_remaining: 600
+        timer_remaining: 600,
+        gameplay_mode: gameplayMode
       })
       .select()
       .single();

--- a/supabase/migrations/20260215000000_add_gameplay_mode_to_game_state.sql
+++ b/supabase/migrations/20260215000000_add_gameplay_mode_to_game_state.sql
@@ -1,0 +1,3 @@
+-- Store gameplay mode (CLASSIC/SUPER/SAGE/...) for multiplayer sync
+ALTER TABLE public.game_state
+ADD COLUMN IF NOT EXISTS gameplay_mode TEXT DEFAULT 'CLASSIC';


### PR DESCRIPTION
### Motivation
- Guests and hosts could run different gameplay logic because the host kept the selected mode in-memory while guests initialized from the `games.mode` enum (which is `multiplayer`), causing mismatched rules/scoring. 
- The change ensures the selected gameplay variant is persisted and used by both host and guest during realtime gameplay to keep behavior consistent.

### Description
- Add a Supabase migration `supabase/migrations/20260215000000_add_gameplay_mode_to_game_state.sql` to add a `gameplay_mode` column to the `game_state` table with default `'CLASSIC'`. 
- Update `src/services/realtime.service.js` to accept a `gameplayMode` parameter in `initializeGameState()` and persist `gameplay_mode` when inserting initial realtime state. 
- Update host and guest flow in `src/lib/multiplayer.js` so the host passes `settings.mode` into `initializeGameState()` and guests initialize `GameLogic` from `game_state.gameplay_mode` instead of `games.mode`. 
- Modify `src/lib/gameLogic.js` to include `gameplay_mode` in `exportForDatabase()` and to import mode from `data.gameplay_mode || data.mode` for backward compatibility, and update the API wrapper `src/api/games.js` to forward the `gameplayMode` parameter. 

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `npm run build` which completed successfully and produced a production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699246ab80e483228603a5e05e2f1de3)